### PR TITLE
Update RelationDataypeForm UI

### DIFF
--- a/packages/@codotype/ui/src/components/relation_editor/RelationDatatypeForm.tsx
+++ b/packages/@codotype/ui/src/components/relation_editor/RelationDatatypeForm.tsx
@@ -1,7 +1,11 @@
 import * as React from "react";
 import { RELATION_META, RelationType, RelationMeta } from "@codotype/types";
+import classname from "classnames";
 
 // // // //
+
+const REL_TYPE_ICON_ROOT_URL =
+    "https://res.cloudinary.com/codotype/image/upload/v1551448517/codotype-icons/";
 
 interface DatatypeOptionProps {
     relationMeta: RelationMeta;
@@ -28,32 +32,46 @@ interface RelationDatatypeFormProps {
  * RelationDatatypeForm
  * @param props - see `RelationDatatypeFormProps`
  */
-export function RelationDatatypeForm(props: RelationDatatypeFormProps) {
-    return (
-        <select
-            className="form-control"
-            value={props.type}
-            onChange={e => {
-                // @ts-ignore
-                props.onChangeRelationType(e.currentTarget.value);
-            }}
-        >
-            {Object.keys(RELATION_META)
-                .filter((relType: string) =>
-                    props.supportedRelationTypes
-                        .map(d => String(d))
-                        .includes(relType),
-                )
-                .map((relType: string) => {
-                    const relationMeta: RelationMeta =
-                        // @ts-ignore
-                        RELATION_META[relType];
-                    return (
-                        <option key={relationMeta.id} value={relationMeta.id}>
-                            {relationMeta.label}
-                        </option>
-                    );
+export function RelationDatatypeForm({
+    type,
+    supportedRelationTypes,
+    onChangeRelationType,
+}: RelationDatatypeFormProps) {
+    const filteredRelationKeys = Object.keys(
+        RELATION_META,
+    ).filter((relType: string) =>
+        supportedRelationTypes.map(d => String(d)).includes(relType),
+    );
+
+    /** Choose either active or normal image for rel type. */
+    const imgSrc = (relType: string) =>
+        `${REL_TYPE_ICON_ROOT_URL}/${relType.toLowerCase()}${
+            relType === String(type) ? "_active.png" : ".png"
+        }`;
+
+    /** Create a button for a rel type that respects which one is active. */
+    const makeRelTypeButton = (relType: string) => {
+        // @ts-ignore
+        const relationMeta: RelationMeta = RELATION_META[relType];
+
+        return (
+            <button
+                key={relationMeta.id}
+                style={{ width: "33%" }}
+                className={classname("btn btn-outline-primary", {
+                    active: relType === type,
                 })}
-        </select>
+                title={relationMeta.label}
+                onClick={() => onChangeRelationType(relationMeta.id)}
+            >
+                <img style={{ width: "60%" }} src={imgSrc(relType)} />
+            </button>
+        );
+    };
+
+    return (
+        <div className="btn-group w-100">
+            {filteredRelationKeys.map(makeRelTypeButton)}
+        </div>
     );
 }

--- a/packages/@codotype/ui/src/components/relation_editor/RelationPropertiesForm.tsx
+++ b/packages/@codotype/ui/src/components/relation_editor/RelationPropertiesForm.tsx
@@ -63,7 +63,9 @@ export function RelationPropertiesForm(props: RelationPropertiesFormProps) {
                     <div className="row">
                         <div className="col-lg-12">
                             <div className="form-group text-center mb-0">
-                                <label className="mb-0">Relation Type</label>
+                                <label className="mb-0">
+                                    {RELATION_META[relationInput.type].label}
+                                </label>
                                 <small className="form-text text-muted mb-0">
                                     {
                                         RELATION_META[relationInput.type]

--- a/packages/@codotype/ui/src/components/relation_editor/RelationPropertiesForm.tsx
+++ b/packages/@codotype/ui/src/components/relation_editor/RelationPropertiesForm.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Schema, RelationType } from "@codotype/types";
+import { Schema, RelationType, RELATION_META } from "@codotype/types";
 import { RelationDatatypeForm } from "./RelationDatatypeForm";
 import { RelationInput } from "./RelationFormModal";
 import { sanitizeLabel, buildRelationReference } from "@codotype/util";
@@ -65,7 +65,10 @@ export function RelationPropertiesForm(props: RelationPropertiesFormProps) {
                             <div className="form-group text-center mb-0">
                                 <label className="mb-0">Relation Type</label>
                                 <small className="form-text text-muted mb-0">
-                                    Relation Desc.
+                                    {
+                                        RELATION_META[relationInput.type]
+                                            .description
+                                    }
                                 </small>
                             </div>
                         </div>


### PR DESCRIPTION
- Switch options to buttons in button group
- Display proper relation type description above
- Closes #149 

![rel_type_buttons](https://user-images.githubusercontent.com/8422699/88246342-35d46b00-cc68-11ea-9bf8-4185bf64fec0.gif)
