### PR TITLE
Add Code of Conduct and Contributing Docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+All participants of Codotype are expected to abide by our Code of Conduct, both online and during in-person events that are hosted and/or associated with Codotype.
+
+
+## The Pledge
+
+In the interest of fostering an open and welcoming environment, we pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+
+## The Standards
+
+Examples of behaviour that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+
+Examples of unacceptable behaviour by participants include:
+
+- Trolling, insulting/derogatory comments, public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Not being respectful to reasonable communication boundaries, such as 'leave me alone,' 'go away,' or 'I’m not discussing this with you.'
+- The usage of sexualised language or imagery and unwelcome sexual attention or advances
+- Demonstrating the graphics or any other content you know may be considered disturbing
+- Starting and/or participating in arguments related to politics
+- Other conduct which you know could reasonably be considered inappropriate in a professional setting.
+
+
+## Enforcement
+
+Violations of the Code of Conduct may be reported by sending an email to codotype.io@gmail.com. All reports will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Further details of specific enforcement policies may be posted separately.
+
+We hold the right and responsibility to remove comments or other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any members for other behaviours that they deem inappropriate, threatening, offensive, or harmful.
+
+
+## Attribution
+
+This Code of Conduct is adapted from dev.to.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change. 
+
+Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+
+## Setup Process
+
+1. [Fork](https://github.com/codotype/codotype/fork) the codotype repository to your GitHub account
+2. Clone your fork to your local computer <br>
+    e.g. `$ git clone git@github.com:Apexal/codotype.git`
+3. Add the original repository as the upstream remote<br>
+    `$ git remote add upstream git@github.com:codotype/codotype.git`
+
+## Development Process
+1. On the master branch, pull in any upstream changes<br>
+    `$ git checkout master && git pull upstream master`
+2. Create a new branch with a name reflecting its purpose
+    - `chore/<short-name>` for chores
+    - `feature/<short-name>` for new features
+    - e.g. `$ git checkout -b chore/add-contributing-docs`
+3. Commit, commit, commit!
+4. Push your branch to your fork when ready<br>
+    `$ git push origin`
+5. <details>
+    <summary>Open a pull request</summary>
+    <img src="https://snipboard.io/aOuodi.jpg">
+
+    List any Issues that you addressed in this branch so that they can be automatically closed
+    <img src="https://snipboard.io/lkiLW1.jpg">
+    </details>


### PR DESCRIPTION
Added both .md files to the project root as suggested by GitHub.

- Closes #77 
- Closes #81 